### PR TITLE
Added learningStats to snn

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
-from .slayerSNN import layer, loihi, params, loss, predict, io, quantize
+from .slayerSNN import layer, loihi, params, loss, predict, io, quantize, learningStats
 
 # from .slayer import spikeLayer as layer
 # from .slayerLoihi import spikeLayer as loihi

--- a/src/slayerSNN.py
+++ b/src/slayerSNN.py
@@ -6,6 +6,7 @@ from .spikeLoss import spikeLoss as loss
 from .spikeClassifier import spikeClassifier as predict
 from . import spikeFileIO as io
 from .quantizeParams import quantizeWeights as quantize
+from .learningStats import learningStats
 
 '''
 This modules bundles various SLAYER PyTorch modules as a single package.


### PR DESCRIPTION
Makes it a little bit easier to access and a bit less verbose
```
import snn
...
snn.learningStats()
```

rather than having a 
```
import snn
from slayerSNN import learningStats as learningStats
...
learningStats()
```
in the imports
