### PR TITLE
Update auto.assistant module to add support to torch.nn.DataParallel

### DIFF
--- a/src/auto/assistant.py
+++ b/src/auto/assistant.py
@@ -39,7 +39,7 @@ class Assistant:
         self.net = net
         self.module = net.module if dataParallel is True else net
         self.error = error
-        self.device = net.slayer.srmKernel.device
+        self.device = self.module.slayer.srmKernel.device
         self.optimizer = optimizer
         self.scheduler = scheduler
         self.stats = stats


### PR DESCRIPTION
Hi @bamsumit,
this PR fixes the initialization.
In fact, if we need to use `torch.nn.dataParallel` for training a model using multiple GPU (in this case `dataParallel` should be set to `True`), we should use `net.module` instead of `net` when initializing `self.device`.
Moreover, since the initialization of `self.module` is done at line # 40, we can use it for the initialization of `self.device`.

Best,
Biagio.